### PR TITLE
fix: parse inlay_hints settings JSON block correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Zed auto-complete to upgrade quickly with the option to show multiple recent rel
 ### Optional loading Indicator
 <img src="./images/inlay.png" width="300"/>
 For an inlay loading indicator, enable inlay hints in Zed:
+
 ```json
 // settings.json
 {


### PR DESCRIPTION
Just a minor README.md file fix

### Before

<img width="882" height="79" alt="Screenshot 2026-05-12 at 1 56 50 PM" src="https://github.com/user-attachments/assets/76491201-40dd-493b-a2de-c3719589d299" />

### After

<img width="1034" height="202" alt="Screenshot 2026-05-12 at 1 54 42 PM" src="https://github.com/user-attachments/assets/73408e1f-69ec-4d39-a848-f36457bc4e7a" />
